### PR TITLE
fix WebApp.clientHash (is now a function)

### DIFF
--- a/appcache-server.js
+++ b/appcache-server.js
@@ -127,7 +127,7 @@ WebApp.connectHandlers.use(function(req, res, next) {
   // So to ensure that the client updates if client resources change,
   // include a hash of client resources in the manifest.
 
-  manifest += "# " + WebApp.clientHash + "\n";
+  manifest += "# " + WebApp.clientHash() + "\n";
 
   // When using the autoupdate package, also include
   // AUTOUPDATE_VERSION.  Otherwise the client will get into an
@@ -137,7 +137,7 @@ WebApp.connectHandlers.use(function(req, res, next) {
 
   if (Package.autoupdate) {
     var version = Package.autoupdate.Autoupdate.autoupdateVersion;
-    if (version !== WebApp.clientHash)
+    if (version !== WebApp.clientHash())
       manifest += "# " + version + "\n";
   }
 

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: "hybrid:appcache-extra"
+  name: "hybrid:appcache-extra",
   summary: "Meteor's appcache + ability to prompt + manually add files",
   version: "0.1.0",
   git: "https://github.com/meteorhybrid/appcache-extra"


### PR DESCRIPTION
changed in meteor:
```
130c80
<   manifest += "# " + WebApp.clientHash + "\n";
---
>   manifest += "# " + WebApp.clientHash() + "\n";
140c90
<     if (version !== WebApp.clientHash)
---
>     if (version !== WebApp.clientHash())
```